### PR TITLE
Update to latest sprs-ldl version to show performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,9 +500,9 @@ checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "sprs"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a239de0976212ca3b83985d8f2ad2611d23a7eefff4c20c60ee5b7bbd3bf5876"
+checksum = "5060adcfb2949b9d63fcead63f8fbcd246099f57144ea8162ad19afead772ff9"
 dependencies = [
  "alga",
  "ndarray",
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "sprs-ldl"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d058db4e0e3d45bcb2dfeffd81739a2bdb2b031788fc21d5ccbd6ea4c5a37101"
+checksum = "43f7954390e6c2e1fa882981673c504161ee9d75d03cb57a7a6bf16671d939f1"
 dependencies = [
  "num-traits 0.1.43",
  "sprs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitflags"
@@ -40,9 +40,9 @@ checksum = "a7b894d1cc14af76750a80f64387f7986fe93a9d3786a9a8926a340ae50b2c51"
 
 [[package]]
 name = "blas-src"
-version = "0.4.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c18550bb5de993fd6ba28b74b05b0aadd693002e566c90cec65636635f570de"
+checksum = "a25f136d1bcc6fc28330077511a0646aaf75bc894e5532b1a33a93d814272328"
 
 [[package]]
 name = "cauchy"
@@ -81,6 +81,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+dependencies = [
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,17 +117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "maybe-uninit",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "fixedbitset"
@@ -148,9 +147,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -158,28 +157,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.15"
+name = "hashbrown"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
 name = "lapack-src"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb27c57e99dddfc00a37e065f1a6ff8fc96e31f85dd2ca0eefcefc3e09fc2571"
+checksum = "92b348b4b770b1092add976188242941b92272f3bad95cfbacadbfcb0c8923eb"
 
 [[package]]
 name = "lapacke"
@@ -209,9 +215,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "libm"
@@ -236,9 +242,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memoffset"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
  "autocfg",
 ]
@@ -249,6 +255,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac06db03ec2f46ee0ecdca1a1c34a99c0d188a0d83439b84bf0cb4b386e4ab09"
 dependencies = [
+ "approx",
  "blas-src 0.2.1",
  "cblas-sys",
  "matrixmultiply",
@@ -260,11 +267,11 @@ dependencies = [
 
 [[package]]
 name = "ndarray-linalg"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5329c636ef41b1382e3990c130ae969137df487004eec51a6e40384f2f646a7a"
+checksum = "6892e51e159690d3d3d9fe2b052ff80b638c7d0f7ce634818c84ab7aea09e01c"
 dependencies = [
- "blas-src 0.4.0",
+ "blas-src 0.6.1",
  "cauchy",
  "lapack-src",
  "lapacke",
@@ -348,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
+checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "rand"
@@ -457,9 +464,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080"
+checksum = "dcf6960dc9a5b4ee8d3e4c5787b4a112a8818e0290a42ff664ad60692fdf2032"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -469,12 +476,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.7.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280"
+checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
 dependencies = [
+ "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-queue",
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
@@ -488,21 +495,21 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.112"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 
 [[package]]
 name = "smallvec"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "sprs"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5060adcfb2949b9d63fcead63f8fbcd246099f57144ea8162ad19afead772ff9"
+checksum = "37647e1bcc6e2e030ea5b36e3d43487af0f9f685daec6c9e0c0b7ae49b2c110a"
 dependencies = [
  "alga",
  "ndarray",
@@ -515,12 +522,13 @@ dependencies = [
 
 [[package]]
 name = "sprs-ldl"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f7954390e6c2e1fa882981673c504161ee9d75d03cb57a7a6bf16671d939f1"
+checksum = "c04fb95f7d2f15f3c8f785c290e309e1bfbd08b8f2736e2bd62b5ba8f2f50098"
 dependencies = [
  "num-traits 0.1.43",
  "sprs",
+ "sprs_suitesparse_camd",
  "sprs_suitesparse_ldl",
 ]
 
@@ -538,14 +546,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "sprs_suitesparse_ldl"
-version = "0.4.0"
+name = "sprs_suitesparse_camd"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d226a8800751c5ad36f36f64de6cd7527e79590d21fccdccf373f63b0693d93"
+checksum = "dc4017a97cb03b14d198b3d6c52733cc0905cc2a458ef6e53c96a8ac18b1d95b"
+dependencies = [
+ "sprs",
+ "suitesparse_camd_sys",
+]
+
+[[package]]
+name = "sprs_suitesparse_ldl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92110fa9d7054dfef537e3fe0082b2f0f1fe67d466652613e7157bfe7f20fcb9"
 dependencies = [
  "num-traits 0.1.43",
  "sprs",
  "suitesparse_ldl_sys",
+]
+
+[[package]]
+name = "suitesparse_camd_sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a347cc5c6302c90a4571f0c8bd910eb63bbd2979f01aed685bc26c3ac1720d"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -565,9 +592,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 ndarray = "0.13.1"
 ndarray-linalg = "0.12.0"
 ndarray-rand = "0.11.0"
-sprs = "0.8.0"
-sprs-ldl = { version = "0.6.0", features = [ "sprs_suitesparse_ldl" ] }
+sprs = "0.8.1"
+sprs-ldl = { version = "0.6.1", features = [ "sprs_suitesparse_ldl" ] }
 petgraph = "0.5.0"
 rand_isaac = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,13 @@ edition = "2018"
 ndarray = "0.13.1"
 ndarray-linalg = "0.12.0"
 ndarray-rand = "0.11.0"
-sprs = "0.8.1"
-sprs-ldl = { version = "0.6.1", features = [ "sprs_suitesparse_ldl" ] }
+sprs = "0.9.1"
 petgraph = "0.5.0"
 rand_isaac = "0.2.0"
+
+[dependencies.sprs-ldl]
+version = "0.7.0"
+features = [
+  "sprs_suitesparse_ldl",
+  "sprs_suitesparse_camd",
+]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,6 @@ fn main() -> Result<(), SprsError> {
         .fill_in_reduction(sprs::FillInReduction::ReverseCuthillMcKee)
         .check_symmetry(sprs::DontCheckSymmetry)
         .numeric(jacobian1.view())?;
-        //.numeric_c(jacobian1.view())?;
     let solution1 = ldl.solve(&rhs1.view().to_slice().unwrap());
     
     ldl.update(jacobian2.view())?;
@@ -71,6 +70,23 @@ fn main() -> Result<(), SprsError> {
     let tstop = std::time::Instant::now();
 
     println!("LdlNumeric took {}ms to solve 3 sparse systems", (tstop - tstart).as_millis());
+
+    let tstart = std::time::Instant::now();
+    let mut ldl = Ldl::new()
+        .fill_in_reduction(sprs::FillInReduction::ReverseCuthillMcKee)
+        .check_symmetry(sprs::DontCheckSymmetry)
+        .numeric_c(jacobian1.view())?;
+    let solution1 = ldl.solve(&rhs1.view().to_slice().unwrap());
+    
+    ldl.update(jacobian2.view())?;
+    let solution2 = ldl.solve(&rhs2.view().to_slice().unwrap());
+
+    ldl.update(jacobian3.view())?;
+    let solution3 = ldl.solve(&rhs3.view().to_slice().unwrap());
+
+    let tstop = std::time::Instant::now();
+
+    println!("LdlNumeric (C version of LDL) took {}ms to solve 3 sparse systems", (tstop - tstart).as_millis());
 
     let tstart = std::time::Instant::now();
     lsolve_csc_dense_rhs(jacobian1.view(), rhs1.view_mut().into_slice().unwrap())?;


### PR DESCRIPTION
I have performed some micro optimization in the `sprs-ldl` code (https://github.com/vbarrielle/sprs/pull/207), and now the performance is similar to the original LDL implementation in C:

```
LdlNumeric took 3683ms to solve 3 sparse systems
LdlNumeric (C version of LDL) took 3675ms to solve 3 sparse systems
```